### PR TITLE
chore: Bump runner to v2.333.1

### DIFF
--- a/ubuntu20.04/Dockerfile
+++ b/ubuntu20.04/Dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/hostinger/fireactions:2.0.3 AS fireactions
 FROM ubuntu:20.04
 
-ARG RUNNER_VERSION="2.331.0"
+ARG RUNNER_VERSION="2.333.1"
 ARG TARGETARCH
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/ubuntu22.04/Dockerfile
+++ b/ubuntu22.04/Dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/hostinger/fireactions:2.0.3 AS fireactions
 FROM ubuntu:22.04
 
-ARG RUNNER_VERSION="2.331.0"
+ARG RUNNER_VERSION="2.333.1"
 ARG TARGETARCH
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/ubuntu24.04/Dockerfile
+++ b/ubuntu24.04/Dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/hostinger/fireactions:2.0.3 AS fireactions
 FROM ubuntu:24.04
 
-ARG RUNNER_VERSION="2.331.0"
+ARG RUNNER_VERSION="2.333.1"
 ARG TARGETARCH
 
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions runner version from 2.331.0 to 2.333.1 across Docker images for Ubuntu 20.04, 22.04, and 24.04.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->