### PR TITLE
chore: Bump runner to v2.334.0

### DIFF
--- a/ubuntu20.04/Dockerfile
+++ b/ubuntu20.04/Dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/hostinger/fireactions:2.0.3 AS fireactions
 FROM ubuntu:20.04
 
-ARG RUNNER_VERSION="2.333.1"
+ARG RUNNER_VERSION="2.334.0"
 ARG TARGETARCH
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/ubuntu22.04/Dockerfile
+++ b/ubuntu22.04/Dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/hostinger/fireactions:2.0.3 AS fireactions
 FROM ubuntu:22.04
 
-ARG RUNNER_VERSION="2.333.1"
+ARG RUNNER_VERSION="2.334.0"
 ARG TARGETARCH
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/ubuntu24.04/Dockerfile
+++ b/ubuntu24.04/Dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/hostinger/fireactions:2.0.3 AS fireactions
 FROM ubuntu:24.04
 
-ARG RUNNER_VERSION="2.333.1"
+ARG RUNNER_VERSION="2.334.0"
 ARG TARGETARCH
 
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions runner to version 2.334.0 across supported container environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hostinger/fireactions-images/pull/72)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->