### PR TITLE
chore: Bump runner to v2.335.1

### DIFF
--- a/ubuntu20.04/Dockerfile
+++ b/ubuntu20.04/Dockerfile
@@ -1,7 +1,7 @@
-FROM ghcr.io/hostinger/fireactions:2.0.3 AS fireactions
+FROM ghcr.io/hostinger/fireactions:2.0.5 AS fireactions
 FROM ubuntu:20.04
 
-ARG RUNNER_VERSION="2.334.0"
+ARG RUNNER_VERSION="2.335.1"
 ARG TARGETARCH
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/ubuntu22.04/Dockerfile
+++ b/ubuntu22.04/Dockerfile
@@ -1,7 +1,7 @@
-FROM ghcr.io/hostinger/fireactions:2.0.3 AS fireactions
+FROM ghcr.io/hostinger/fireactions:2.0.5 AS fireactions
 FROM ubuntu:22.04
 
-ARG RUNNER_VERSION="2.334.0"
+ARG RUNNER_VERSION="2.335.1"
 ARG TARGETARCH
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/ubuntu24.04/Dockerfile
+++ b/ubuntu24.04/Dockerfile
@@ -1,7 +1,7 @@
-FROM ghcr.io/hostinger/fireactions:2.0.3 AS fireactions
+FROM ghcr.io/hostinger/fireactions:2.0.5 AS fireactions
 FROM ubuntu:24.04
 
-ARG RUNNER_VERSION="2.334.0"
+ARG RUNNER_VERSION="2.335.1"
 ARG TARGETARCH
 
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build environment across supported Ubuntu images to newer, more stable versions.
  * Bumped the default runner version to a newer release for improved compatibility and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->